### PR TITLE
Use NonNull<T> instead of &T internally for soundness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beef"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 edition = "2018"
 description = "More compact Cow"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,6 +344,7 @@ impl<T: Beef + fmt::Display + ?Sized> fmt::Display for Cow<'_, T> {
 }
 
 unsafe impl<T: Beef + Sync + ?Sized> Sync for Cow<'_, T> {}
+unsafe impl<T: Beef + Send + ?Sized> Send for Cow<'_, T> {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This is to avoid converting `Vec<T>` to `&[T]` back to `Vec<T>`, which might lead to UB.

We now have to upcast `*const [T]` to `*mut [T]` internally when borrowing, but those pointers are always dereferenced back to `&[T]`, thus avoiding the original issue.