### PR TITLE
Avoid pointer casting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beef"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 edition = "2018"
 description = "More compact Cow"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,15 +183,11 @@ where
     /// Clones the data if it is not already owned.
     #[inline]
     pub fn into_owned(self) -> T::Owned {
-        let Cow {
-            inner, capacity, ..
-        } = self;
+        let cow = mem::ManuallyDrop::new(self);
 
-        mem::forget(self);
-
-        match capacity {
-            Some(capacity) => unsafe { T::rebuild(inner, capacity.get()) },
-            None => unsafe { inner.as_ref() }.to_owned(),
+        match cow.capacity {
+            Some(capacity) => unsafe { T::rebuild(cow.inner, capacity.get()) },
+            None => unsafe { cow.inner.as_ref() }.to_owned(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,11 +74,12 @@ unsafe impl Beef for str {
 
     #[inline]
     unsafe fn owned_ptr(mut owned: String) -> NonNull<str> {
-        let ptr = owned.as_mut_str() as *mut str;
+        let ptr = owned.as_mut_ptr();
+        let len = owned.len();
 
         mem::forget(owned);
 
-        NonNull::new_unchecked(ptr)
+        NonNull::new_unchecked(slice_from_raw_parts_mut(ptr, len) as *mut str)
     }
 
     #[inline]


### PR DESCRIPTION
+ Fixes #7, no longer casting `&mut T as *mut T`.
+ `Beef::owned_ptr` is no longer marked as `unsafe`.