### PR TITLE
run Miri on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
       name: "nightly all features"
       script:
         - cargo build --all-features
+    - rust: nightly
+      name: "Miri"
+      script:
+        - ci/miri.sh
 jobs:
   allow_failures:
     - rust: nightly

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
+rustup set profile minimal
+rustup default "$MIRI_NIGHTLY"
+
+rustup component add miri
+cargo miri setup
+
+# FIXME: investigate memory leaks
+cargo miri test --all-features -- -Zmiri-ignore-leaks


### PR DESCRIPTION
After discussions like https://github.com/maciejhirsz/beef/issues/7, I figured running Miri to check the test suite for UB might be a good idea. However, I am not sure how extensive the test suite is so far. Miri can only find UB if the test suite actually hits the problematic code paths (think of it like ubsan or other sanitizers).

It seems like `cargo test` is not even run on CI?