### PR TITLE
Reorder Lean store by how it was stored

### DIFF
--- a/src/lean.rs
+++ b/src/lean.rs
@@ -41,7 +41,7 @@ impl Capacity for Lean {
             panic!("beef::lean::Cow: Capacity out of bounds");
         }
 
-        let fat = (len & MASK_LO) | ((capacity & MASK_LO) << 32);
+        let fat = ((capacity & MASK_LO) << 32) | (len & MASK_LO);
 
         (fat, Lean)
     }


### PR DESCRIPTION
(cap, len) would be easier to read since it is how it was stored.