### PR TITLE
0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beef"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 edition = "2018"
 description = "More compact Cow"
@@ -21,8 +21,8 @@ serde_json = "1.0"
 [features]
 default = []
 
-# adds `Cow::const_str` and `Cow::const_slice`, which are const fn
-# alternatives for creating &str and &[T] borrows
+# adds `Cow::const_slice`, the const fn alternative to `Cow::borrowed` for
+# generic &[T] slices.
 # requires nightly: https://github.com/rust-lang/rust/issues/57563
 const_fn = []
 

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -10,8 +10,9 @@ use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 
-use crate::wide::internal::Wide;
+#[cfg(target_pointer_width = "64")]
 use crate::lean::internal::Lean;
+use crate::wide::internal::Wide;
 use crate::traits::{Beef, Capacity};
 
 /// A clone-on-write smart pointer, mostly compatible with [`std::borrow::Cow`](https://doc.rust-lang.org/std/borrow/enum.Cow.html).
@@ -188,6 +189,7 @@ impl<'a> Cow<'a, str, Wide> {
     }
 }
 
+#[cfg(target_pointer_width = "64")]
 impl<'a> Cow<'a, str, Lean> {
     /// Borrowed data.
     ///
@@ -246,7 +248,7 @@ where
 
 // This requires nightly:
 // https://github.com/rust-lang/rust/issues/57563
-#[cfg(feature = "const_fn")]
+#[cfg(all(feature = "const_fn", target_pointer_width = "64"))]
 impl<'a, T> Cow<'a, [T], Lean>
 where
     T: Clone,

--- a/src/lean.rs
+++ b/src/lean.rs
@@ -12,7 +12,7 @@ use crate::traits::Capacity;
 /// top level `beef::Cow` if you wish to avoid this problem.
 pub type Cow<'a, T> = crate::generic::Cow<'a, T, Lean>;
 
-mod internal {
+pub(crate) mod internal {
     #[derive(Clone, Copy, PartialEq, Eq)]
     pub struct Lean;
 }
@@ -20,6 +20,13 @@ use internal::Lean;
 
 const MASK_LO: usize = u32::max_value() as usize;
 const MASK_HI: usize = !(u32::max_value() as usize);
+
+impl Lean {
+    #[inline]
+    pub const fn mask_len(len: usize) -> usize {
+        len & MASK_LO
+    }
+}
 
 impl Capacity for Lean {
     type Field = Lean;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,21 @@ macro_rules! test { ($tmod:ident => $cow:path) => {
 
             assert_eq!(expected, cow.into_owned());
         }
+
+        #[test]
+        fn const_fn_str() {
+            const HELLO: Cow<str> = Cow::const_str("Hello");
+
+            assert_eq!(&*HELLO, "Hello");
+        }
+
+        #[test]
+        #[cfg(feature = "const_fn")]
+        fn const_fn_slice() {
+            const FOO: Cow<[u8]> = Cow::const_slice(b"bar");
+
+            assert_eq!(&*FOO, b"bar");
+        }
     }
 } }
 


### PR DESCRIPTION
+ `const_str` and `const_slice` are now available for both `beef::Cow` and `beef::lean::Cow`.
+ `const_str` no longer requires nightly and is available without a feature flag.