### PR TITLE
Fix Sync and Send markers, add Unpin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beef"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["Maciej Hirsz <hello@maciej.codes>"]
 edition = "2018"
 description = "More compact Cow"

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -528,5 +528,23 @@ where
 }
 
 // Safety: Same bounds as `std::borrow::Cow`.
-unsafe impl<T: Beef + Sync + ?Sized, U: Capacity> Sync for Cow<'_, T, U> {}
-unsafe impl<T: Beef + Send + Sync + ?Sized, U: Capacity> Send for Cow<'_, T, U> {}
+unsafe impl<T, U> Sync for Cow<'_, T, U>
+where
+    U: Capacity,
+    T: Beef + Sync + ?Sized,
+    T::Owned: Sync,
+{}
+
+unsafe impl<T, U> Send for Cow<'_, T, U>
+where
+    U: Capacity,
+    T: Beef + Sync + ?Sized,
+    T::Owned: Send,
+{}
+
+impl<T, U> Unpin for Cow<'_, T, U>
+where
+    U: Capacity,
+    T: Beef + ?Sized,
+    T::Owned: Unpin,
+{}

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -533,18 +533,21 @@ where
     U: Capacity,
     T: Beef + Sync + ?Sized,
     T::Owned: Sync,
-{}
+{
+}
 
 unsafe impl<T, U> Send for Cow<'_, T, U>
 where
     U: Capacity,
     T: Beef + Sync + ?Sized,
     T::Owned: Send,
-{}
+{
+}
 
 impl<T, U> Unpin for Cow<'_, T, U>
 where
     U: Capacity,
     T: Beef + ?Sized,
     T::Owned: Unpin,
-{}
+{
+}


### PR DESCRIPTION
I think I got a bit too fast with #38. This should be analog to std `Cow`, also added `Unpin` because why not.

cc @ammaraskar @JOE1994