### PR TITLE
Implement `beef::lean::Cow` on other pointer widths

### DIFF
--- a/src/lean.rs
+++ b/src/lean.rs
@@ -2,14 +2,17 @@
 
 use crate::traits::Capacity;
 
-/// Faster, 2-word `Cow`. This version is available only on 64-bit architecture,
-/// and it puts both capacity and length together in a fat pointer. Both length and capacity
-/// is limited to 32 bits.
+/// Faster, 2-word `Cow`.
+///
+/// This version puts both capacity and length together in a fat pointer.
+/// Both length and capacity are stored evenly through out the target pointer's width.
+///
+/// For example, on a machine with a pointer width of 64. both length and capacity would occupy 32 bits.
 ///
 /// # Panics
 ///
-/// [`Cow::owned`](../generic/struct.Cow.html#method.owned) will panic if capacity is larger than `u32::max_size()`. Use the
-/// top level `beef::Cow` if you wish to avoid this problem.
+/// [`Cow::owned`](../generic/struct.Cow.html#method.owned) will panic if capacity is larger than half the pointer width.
+/// Use the top level `beef::Cow` if you wish to avoid this problem.
 pub type Cow<'a, T> = crate::generic::Cow<'a, T, Lean>;
 
 pub(crate) mod internal {

--- a/src/lean.rs
+++ b/src/lean.rs
@@ -18,7 +18,8 @@ pub(crate) mod internal {
 }
 use internal::Lean;
 
-const MASK_LO: usize = u32::MAX as usize;
+const POINTER_SIZE: usize = core::mem::size_of::<usize>() * 8;
+const MASK_LO: usize = usize::MAX >> (POINTER_SIZE / 2);
 const MASK_HI: usize = !MASK_LO;
 
 impl Lean {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,14 +44,7 @@ mod wide;
 mod serde;
 
 pub mod generic;
-#[cfg(target_pointer_width = "64")]
 pub mod lean;
-
-#[cfg(not(target_pointer_width = "64"))]
-pub mod lean {
-    /// Re-exports 3-word Cow for non-64-bit targets
-    pub use super::wide::Cow;
-}
 
 pub use wide::Cow;
 


### PR DESCRIPTION
This should remove the restriction on `beef::lean::Cow` being only available on targets with a pointer width of 64