### PR TITLE
Specialize Deserialize to always borrow `Cow<str>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@
 //!
 //! assert_eq!(size_of::<std::borrow::Cow<str>>(), 4 * WORD);
 //! assert_eq!(size_of::<beef::Cow<str>>(), 3 * WORD);
+//!
+//! // Lean variant is two words on 64-bit architecture
+//! #[cfg(target_pointer_width = "64")]
 //! assert_eq!(size_of::<beef::lean::Cow<str>>(), 2 * WORD);
 //! ```
 #![cfg_attr(feature = "const_fn", feature(const_fn_trait_bound))]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, borrow::ToOwned};
+use alloc::{borrow::ToOwned, string::String};
 use core::{fmt, marker::PhantomData};
 
 use serde::de::{self, Deserialize, Deserializer, Visitor};
@@ -20,7 +20,9 @@ where
     }
 }
 
-struct CowVisitor<'de, 'a, T: Beef + ?Sized, U: Capacity>(PhantomData<fn() -> (&'de T, Cow<'a, T, U>)>);
+struct CowVisitor<'de, 'a, T: Beef + ?Sized, U: Capacity>(
+    PhantomData<fn() -> (&'de T, Cow<'a, T, U>)>,
+);
 
 impl<'de, 'a, U> Visitor<'de> for CowVisitor<'de, 'a, str, U>
 where

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,4 +1,7 @@
-use serde::de::{Deserialize, Deserializer};
+use alloc::{string::String, borrow::ToOwned};
+use core::{fmt, marker::PhantomData};
+
+use serde::de::{self, Deserialize, Deserializer, Visitor};
 use serde::ser::{Serialize, Serializer};
 
 use crate::generic::Cow;
@@ -17,18 +20,67 @@ where
     }
 }
 
-impl<'de, 'a, T: ?Sized, U> Deserialize<'de> for Cow<'a, T, U>
+struct CowVisitor<'de, 'a, T: Beef + ?Sized, U: Capacity>(PhantomData<fn() -> (&'de T, Cow<'a, T, U>)>);
+
+impl<'de, 'a, U> Visitor<'de> for CowVisitor<'de, 'a, str, U>
 where
-    T: Beef,
+    'de: 'a,
     U: Capacity,
-    T::Owned: Deserialize<'de>,
+{
+    type Value = Cow<'a, str, U>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a string")
+    }
+
+    fn visit_borrowed_str<E>(self, value: &'de str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Cow::borrowed(value))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Cow::owned(value.to_owned()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Cow::owned(value))
+    }
+}
+
+impl<'de, 'a, U> Deserialize<'de> for Cow<'a, str, U>
+where
+    'de: 'a,
+    U: Capacity,
 {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        T::Owned::deserialize(deserializer).map(Cow::owned)
+        deserializer.deserialize_str(CowVisitor::<'de, 'a, str, U>(PhantomData))
+    }
+}
+
+impl<'de, 'a, T, U> Deserialize<'de> for Cow<'a, [T], U>
+where
+    [T]: Beef,
+    U: Capacity,
+    <[T] as ToOwned>::Owned: Deserialize<'de>,
+{
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        <[T] as ToOwned>::Owned::deserialize(deserializer).map(Cow::owned)
     }
 }
 
@@ -59,5 +111,37 @@ mod tests {
         let out = serde_json::to_string(&test).unwrap();
 
         assert_eq!(json, out);
+    }
+
+    #[test]
+    fn wide_cow_direct() {
+        use crate::Cow;
+
+        let json = r#""foo""#;
+        let cow: Cow<str> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(cow, "foo");
+
+        assert!(cow.is_borrowed());
+
+        let json = r#""\tfoo""#;
+        let cow: Cow<str> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(cow, "\tfoo");
+
+        assert!(cow.is_owned());
+    }
+
+    #[test]
+    fn wide_cow_direct_bytes() {
+        use crate::Cow;
+
+        let json = r#"[102, 111, 111]"#;
+        let cow: Cow<[u8]> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(cow, &b"foo"[..]);
+
+        // We need to stay generic over `[T]`, so no specialization for byte slices
+        assert!(cow.is_owned());
     }
 }


### PR DESCRIPTION
Since `beef::Cow` is only compatible with `str` and `[T]`, we can specialize the `serde::Deserialize` for `Cow<str>` so that it always borrows when possible. This has the advantage over `std::borrow::Cow` when deserializing into `Cow<str>` directly:

```rust
let json = r#""foo""#;
let std_cow: std::borrow::Cow<str> = serde_json::from_str(json).unwrap(); // will always deserialize to `Cow::Owned` with an allocation
let beef_cow: beef::Cow<str> = serde_json::from_str(json).unwrap(); // will be borrowed since `foo` can be borrowed from the `json` slice
```