### PR TITLE
Fix `into_owned` `String` not having enough provenance

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -9,4 +9,4 @@ rustup default "$MIRI_NIGHTLY"
 rustup component add miri
 cargo miri setup
 
-cargo miri test --all-features
+MIRIFLAGS='-Zmiri-strict-provenance' cargo miri test --all-features

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -94,7 +94,9 @@ pub(crate) mod internal {
             U: Capacity,
         {
             // Convert to `String::into_raw_parts` once stabilized
-            let mut owned = ManuallyDrop::new(owned);
+            // We need to go through Vec here to get provenance for the entire allocation
+            // instead of just the initialized parts.
+            let mut owned = ManuallyDrop::new(owned.into_bytes());
             let (fat, cap) = U::store(owned.len(), owned.capacity());
 
             (


### PR DESCRIPTION
Calling `.as_mut_ptr` on a `String` actually goes through `&mut str`, which shrinks the provenance of the pointer to only contain the initialized bytes. This caused issues when a reconstructed `String` tried to write to the uninitialized part of it. The fix is to go through `Vec::<u8>::as_mut_ptr`, which gives provenance for the entire allocation.