### PR TITLE
Implements `const_deref` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ default = []
 # generic &[T] slices.
 # requires nightly: https://github.com/rust-lang/rust/issues/57563
 const_fn = []
+# requires nightly: https://github.com/rust-lang/rust/issues/67792
+const_deref = []
 
 impl_serde = ["serde"]
 

--- a/src/cfg_fix.rs
+++ b/src/cfg_fix.rs
@@ -1,0 +1,13 @@
+// macro for hack this problem: https://github.com/rust-lang/rust/issues/99675
+// also can use `cfg_if` crate
+macro_rules! cfg_fix {
+    (#[cfg($meta:meta)] { $($tokens:tt)* }) => {
+        #[cfg($meta)] $crate::cfg_fix! { @identity $($tokens)* }
+    };
+
+    (@identity $($tokens:tt)*) => {
+        $($tokens)*
+    };
+}
+
+pub(crate) use cfg_fix;

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -13,7 +13,7 @@ use core::ptr::NonNull;
 
 #[cfg(target_pointer_width = "64")]
 use crate::lean::internal::Lean;
-use crate::traits::{Beef, Capacity};
+use crate::traits::{Beef, Capacity, Steak};
 use crate::wide::internal::Wide;
 
 /// A clone-on-write smart pointer, mostly compatible with [`std::borrow::Cow`](https://doc.rust-lang.org/std/borrow/enum.Cow.html).
@@ -67,24 +67,57 @@ where
     T: Beef + ?Sized,
     U: Capacity,
 {
-    /// Borrowed data.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use beef::Cow;
-    ///
-    /// let borrowed: Cow<str> = Cow::borrowed("I'm just a borrow");
-    /// ```
-    #[inline]
-    pub fn borrowed(val: &'a T) -> Self {
-        let (ptr, fat, cap) = T::ref_into_parts::<U>(val);
+    crate::cfg_fix! {
+        #[cfg(not(feature = "const_deref"))] {
+            /// Borrowed data.
+            ///
+            /// # Example
+            ///
+            /// ```rust
+            /// use beef::Cow;
+            ///
+            /// let borrowed: Cow<str> = Cow::borrowed("I'm just a borrow");
+            /// ```
+            ///
+            #[inline]
+            pub fn borrowed(val: &'a T) -> Self {
+                let (ptr, fat, cap) = T::ref_into_parts::<U>(val);
 
-        Cow {
-            ptr,
-            fat,
-            cap,
-            marker: PhantomData,
+                Cow {
+                    ptr,
+                    fat,
+                    cap,
+                    marker: PhantomData,
+                }
+            }
+        }
+    }
+
+    crate::cfg_fix! {
+        #[cfg(feature = "const_deref")] {
+            /// Borrowed data.
+            ///
+            /// # Example
+            ///
+            /// ```rust
+            /// use beef::Cow;
+            ///
+            /// let borrowed: Cow<str> = Cow::borrowed("I'm just a borrow");
+            /// ```
+            ///
+            #[inline]
+            pub const fn borrowed(val: &'a T) -> Self
+            where T: ~const Steak
+            {
+                let (ptr, fat, cap) = T::ref_into_parts::<U>(val);
+
+                Cow {
+                    ptr,
+                    fat,
+                    cap,
+                    marker: PhantomData,
+                }
+            }
         }
     }
 
@@ -152,10 +185,24 @@ where
         self.capacity().is_some()
     }
 
-    /// Internal convenience method for casting `ptr` into a `&T`
-    #[inline]
-    fn borrow(&self) -> &T {
-        unsafe { &*T::ref_from_parts::<U>(self.ptr, self.fat) }
+    crate::cfg_fix! {
+        #[cfg(not(feature = "const_deref"))] {
+            /// Internal convenience method for casting `ptr` into a `&T`
+            #[inline]
+            fn borrow(&self) -> &T {
+                unsafe { &*T::ref_from_parts::<U>(self.ptr, self.fat) }
+            }
+        }
+    }
+
+    crate::cfg_fix! {
+        #[cfg(feature = "const_deref")] {
+            /// Internal convenience method for casting `ptr` into a `&T`
+            #[inline]
+            const fn borrow(&self) -> &T where T: ~const Steak {
+                unsafe { &*T::ref_from_parts::<U>(self.ptr, self.fat) }
+            }
+        }
     }
 
     #[inline]
@@ -177,6 +224,10 @@ impl<'a> Cow<'a, str, Wide> {
     ///
     /// const HELLO: Cow<str> = Cow::const_str("Hello");
     /// ```
+    #[cfg_attr(
+        feature = "const_deref",
+        deprecated(note = "use Cow::borrowed() instead")
+    )]
     pub const fn const_str(val: &'a str) -> Self {
         Cow {
             // We are casting *const T to *mut T, however for all borrowed values
@@ -203,6 +254,10 @@ impl<'a> Cow<'a, str, Lean> {
     ///
     /// const HELLO: Cow<str> = Cow::const_str("Hello");
     /// ```
+    #[cfg_attr(
+        feature = "const_deref",
+        deprecated(note = "use Cow::borrowed() instead")
+    )]
     pub const fn const_str(val: &'a str) -> Self {
         Cow {
             // We are casting *const T to *mut T, however for all borrowed values
@@ -234,6 +289,10 @@ where
     ///
     /// const HELLO: Cow<[u8]> = Cow::const_slice(&[1, 2, 3]);
     /// ```
+    #[cfg_attr(
+        feature = "const_deref",
+        deprecated(note = "use Cow::borrowed() instead")
+    )]
     pub const fn const_slice(val: &'a [T]) -> Self {
         Cow {
             // We are casting *const T to *mut T, however for all borrowed values
@@ -265,6 +324,10 @@ where
     ///
     /// const HELLO: Cow<[u8]> = Cow::const_slice(&[1, 2, 3]);
     /// ```
+    #[cfg_attr(
+        feature = "const_deref",
+        deprecated(note = "use Cow::borrowed() instead")
+    )]
     pub const fn const_slice(val: &'a [T]) -> Self {
         Cow {
             // We are casting *const T to *mut T, however for all borrowed values
@@ -390,38 +453,108 @@ where
     }
 }
 
-impl<T, U> core::ops::Deref for Cow<'_, T, U>
-where
-    T: Beef + ?Sized,
-    U: Capacity,
-{
-    type Target = T;
+crate::cfg_fix! {
+    #[cfg(not(feature = "const_deref"))] {
+        impl<T, U> core::ops::Deref for Cow<'_, T, U>
+        where
+            T: Beef + ?Sized,
+            U: Capacity,
+        {
+            type Target = T;
 
-    #[inline]
-    fn deref(&self) -> &T {
-        self.borrow()
+            #[inline]
+            fn deref(&self) -> &T {
+                self.borrow()
+            }
+        }
+
+        impl<T, U> AsRef<T> for Cow<'_, T, U>
+        where
+            T: Beef + ?Sized,
+            U: Capacity,
+        {
+            #[inline]
+            fn as_ref(&self) -> &T {
+                self.borrow()
+            }
+        }
+
+        impl<T, U> Borrow<T> for Cow<'_, T, U>
+        where
+            T: Beef + ?Sized,
+            U: Capacity,
+        {
+            #[inline]
+            fn borrow(&self) -> &T {
+                self.borrow()
+            }
+        }
+
+        impl<A, B, U, V> PartialEq<Cow<'_, B, V>> for Cow<'_, A, U>
+        where
+            A: Beef + ?Sized,
+            B: Beef + ?Sized,
+            U: Capacity,
+            V: Capacity,
+            A: PartialEq<B>,
+        {
+            fn eq(&self, other: &Cow<B, V>) -> bool {
+                self.borrow() == other.borrow()
+            }
+        }
     }
 }
 
-impl<T, U> AsRef<T> for Cow<'_, T, U>
-where
-    T: Beef + ?Sized,
-    U: Capacity,
-{
-    #[inline]
-    fn as_ref(&self) -> &T {
-        self.borrow()
-    }
-}
+crate::cfg_fix! {
+    #[cfg(feature = "const_deref")] {
+        impl<T, U> const core::ops::Deref for Cow<'_, T, U>
+        where
+            T: Beef + ?Sized + ~const Steak,
+            U: Capacity,
+        {
+            type Target = T;
 
-impl<T, U> Borrow<T> for Cow<'_, T, U>
-where
-    T: Beef + ?Sized,
-    U: Capacity,
-{
-    #[inline]
-    fn borrow(&self) -> &T {
-        self.borrow()
+            #[inline]
+            fn deref(&self) -> &T {
+                self.borrow()
+            }
+        }
+
+        impl<T, U> const AsRef<T> for Cow<'_, T, U>
+        where
+            T: Beef + ?Sized + ~const Steak,
+            U: Capacity,
+        {
+            #[inline]
+            fn as_ref(&self) -> &T {
+                self.borrow()
+            }
+        }
+
+        impl<T, U> const Borrow<T> for Cow<'_, T, U>
+        where
+            T: Beef + ?Sized + ~const Steak,
+            U: Capacity,
+        {
+            #[inline]
+            fn borrow(&self) -> &T {
+                self.borrow()
+            }
+        }
+
+        impl<A, B, U, V> const PartialEq<Cow<'_, B, V>> for Cow<'_, A, U>
+        where
+            A: Beef + ?Sized + ~const Steak,
+            B: Beef + ?Sized + ~const Steak,
+            U: Capacity,
+            V: Capacity,
+            A: ~const PartialEq<B>,
+        {
+            fn eq(&self, other: &Cow<B, V>) -> bool {
+                // fixme: compile error within `a == b` context :(
+                self.borrow().eq(other.borrow())
+            }
+        }
     }
 }
 
@@ -454,19 +587,6 @@ where
             }
             None => StdCow::Borrowed(unsafe { &*T::ref_from_parts::<U>(cow.ptr, cow.fat) }),
         }
-    }
-}
-
-impl<A, B, U, V> PartialEq<Cow<'_, B, V>> for Cow<'_, A, U>
-where
-    A: Beef + ?Sized,
-    B: Beef + ?Sized,
-    U: Capacity,
-    V: Capacity,
-    A: PartialEq<B>,
-{
-    fn eq(&self, other: &Cow<B, V>) -> bool {
-        self.borrow() == other.borrow()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@
 //! assert_eq!(size_of::<beef::lean::Cow<str>>(), 2 * WORD);
 //! ```
 #![cfg_attr(feature = "const_fn", feature(const_fn_trait_bound))]
+#![cfg_attr(feature = "const_deref", feature(const_trait_impl))]
+#![cfg_attr(feature = "const_deref", feature(const_deref))]
 #![warn(missing_docs)]
 #![cfg_attr(not(test), no_std)]
 extern crate alloc;
@@ -49,6 +51,10 @@ mod serde;
 pub mod generic;
 #[cfg(target_pointer_width = "64")]
 pub mod lean;
+
+pub(crate) mod cfg_fix;
+
+pub(crate) use cfg_fix::cfg_fix;
 
 #[cfg(not(target_pointer_width = "64"))]
 pub mod lean {
@@ -264,6 +270,16 @@ macro_rules! test { ($tmod:ident => $cow:path) => {
 
             assert_eq!(&*FOO, b"bar");
         }
+        
+        #[test]
+        #[cfg(feature = "const_deref")]
+        fn real_const_fn_slice() {
+            const FOO: Cow<[u8]> = Cow::borrowed(b"bar");
+            const BAR: &[u8] = &*FOO;
+        
+            assert_eq!(BAR, b"bar");
+        }
+
 
         #[test]
         fn default_str() {

--- a/src/wide.rs
+++ b/src/wide.rs
@@ -11,32 +11,70 @@ pub(crate) mod internal {
 }
 use internal::Wide;
 
-impl Capacity for Wide {
-    type Field = Option<NonZeroUsize>;
-    type NonZero = NonZeroUsize;
+crate::cfg_fix! {
+    #[cfg(not(feature = "const_deref"))] {
+        impl Capacity for Wide {
+            type Field = Option<NonZeroUsize>;
+            type NonZero = NonZeroUsize;
 
-    #[inline]
-    fn len(fat: usize) -> usize {
-        fat
+            #[inline]
+            fn len(fat: usize) -> usize {
+                fat
+            }
+
+            #[inline]
+            fn empty(len: usize) -> (usize, Self::Field) {
+                (len, None)
+            }
+
+            #[inline]
+            fn store(len: usize, capacity: usize) -> (usize, Self::Field) {
+                (len, NonZeroUsize::new(capacity))
+            }
+
+            #[inline]
+            fn unpack(fat: usize, capacity: NonZeroUsize) -> (usize, usize) {
+                (fat, capacity.get())
+            }
+
+            #[inline]
+            fn maybe(_: usize, capacity: Option<NonZeroUsize>) -> Option<NonZeroUsize> {
+                capacity
+            }
+        }
     }
+}
 
-    #[inline]
-    fn empty(len: usize) -> (usize, Self::Field) {
-        (len, None)
-    }
+crate::cfg_fix! {
+    #[cfg(feature = "const_deref")] {
+        impl const Capacity for Wide {
+            type Field = Option<NonZeroUsize>;
+            type NonZero = NonZeroUsize;
 
-    #[inline]
-    fn store(len: usize, capacity: usize) -> (usize, Self::Field) {
-        (len, NonZeroUsize::new(capacity))
-    }
+            #[inline]
+            fn len(fat: usize) -> usize {
+                fat
+            }
 
-    #[inline]
-    fn unpack(fat: usize, capacity: NonZeroUsize) -> (usize, usize) {
-        (fat, capacity.get())
-    }
+            #[inline]
+            fn empty(len: usize) -> (usize, Self::Field) {
+                (len, None)
+            }
 
-    #[inline]
-    fn maybe(_: usize, capacity: Option<NonZeroUsize>) -> Option<NonZeroUsize> {
-        capacity
+            #[inline]
+            fn store(len: usize, capacity: usize) -> (usize, Self::Field) {
+                (len, NonZeroUsize::new(capacity))
+            }
+
+            #[inline]
+            fn unpack(fat: usize, capacity: NonZeroUsize) -> (usize, usize) {
+                (fat, capacity.get())
+            }
+
+            #[inline]
+            fn maybe(_: usize, capacity: Option<NonZeroUsize>) -> Option<NonZeroUsize> {
+                capacity
+            }
+        }
     }
 }


### PR DESCRIPTION
`const_deref` feature should add almost all `const` functionality from `std::borrow::Cow`

Sorry for the code duplication 