### PR TITLE
Export traits while still hiding the implementation details

### DIFF
--- a/src/generic.rs
+++ b/src/generic.rs
@@ -13,7 +13,7 @@ use core::ptr::NonNull;
 
 #[cfg(target_pointer_width = "64")]
 use crate::lean::internal::Lean;
-use crate::traits::{Beef, Capacity};
+pub use crate::traits::{Beef, Capacity};
 use crate::wide::internal::Wide;
 
 /// A clone-on-write smart pointer, mostly compatible with [`std::borrow::Cow`](https://doc.rust-lang.org/std/borrow/enum.Cow.html).

--- a/src/lean.rs
+++ b/src/lean.rs
@@ -1,6 +1,6 @@
 //! Namespace containing the 2-word `Cow` implementation.
 
-use crate::traits::Capacity;
+use crate::traits::InternalCapacity;
 
 /// Faster, 2-word `Cow`. This version is available only on 64-bit architecture,
 /// and it puts both capacity and length together in a fat pointer. Both length and capacity
@@ -28,7 +28,7 @@ impl Lean {
     }
 }
 
-impl Capacity for Lean {
+impl InternalCapacity for Lean {
     type Field = Lean;
     type NonZero = Lean;
 

--- a/src/wide.rs
+++ b/src/wide.rs
@@ -1,4 +1,4 @@
-use crate::traits::Capacity;
+use crate::traits::InternalCapacity;
 use core::num::NonZeroUsize;
 
 /// Compact three word `Cow` that puts the ownership tag in capacity.
@@ -11,7 +11,7 @@ pub(crate) mod internal {
 }
 use internal::Wide;
 
-impl Capacity for Wide {
+impl InternalCapacity for Wide {
     type Field = Option<NonZeroUsize>;
     type NonZero = NonZeroUsize;
 


### PR DESCRIPTION
I'm working on https://crates.io/crates/ownable, a crate that helps with Cow.
And I thought that I could also support beef (even though I've never used it so far).

But It's not possible to add a generic impl because Beef and Capacity are not exported.

This patch does export them, and hides the internal details in another trait.

There are a few todos, please say what you like and I'dd edit it:
- choice of impl the exported traits
- documentation for Beef and Capacity

Edit: the adaption for ownable is here: https://github.com/alexkazik/ownable/compare/main...beef
