### PR TITLE
Add const accessors for data

### DIFF
--- a/src/generic.rs
+++ b/src/generic.rs
@@ -188,16 +188,14 @@ where
     /// Returns capacity of underlying data
     #[inline]
     pub const fn capacity(&self) -> Option<usize> {
-        match self.cap {
-            Some(_) => unsafe {
+        if self.cap.is_some() {
+            Some(unsafe {
                 // SAFETY: Transmute from Option<NonZero<usize>> to usize is
                 // sound by definition.
-                Some(core::mem::transmute::<
-                    Option<core::num::NonZero<usize>>,
-                    usize,
-                >(self.cap))
-            },
-            None => None,
+                core::mem::transmute::<Option<core::num::NonZero<usize>>, usize>(self.cap)
+            })
+        } else {
+            None
         }
     }
 }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -162,6 +162,12 @@ where
     fn capacity(&self) -> Option<U::NonZero> {
         U::maybe(self.fat, self.cap)
     }
+
+    /// Accessor for the underlying data
+    #[inline]
+    pub const fn get_raw_ptr(&self) -> NonNull<T::PointerT> {
+        self.ptr
+    }
 }
 
 impl<'a> Cow<'a, str, Wide> {

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -175,6 +175,7 @@ where
     T: Beef + ?Sized,
 {
     /// Returns `true` if the contained data is empty
+    #[inline]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -204,6 +205,7 @@ where
     T: Beef + ?Sized,
 {
     /// Returns `true` if the contained data is empty
+    #[inline]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/src/lean.rs
+++ b/src/lean.rs
@@ -26,10 +26,6 @@ impl Lean {
     pub const fn mask_len(len: usize) -> usize {
         len & MASK_LO
     }
-    #[inline]
-    pub const fn mask_cap(cap: usize) -> usize {
-        (cap & MASK_HI) >> 4
-    }
 }
 
 impl InternalCapacity for Lean {

--- a/src/lean.rs
+++ b/src/lean.rs
@@ -26,6 +26,10 @@ impl Lean {
     pub const fn mask_len(len: usize) -> usize {
         len & MASK_LO
     }
+    #[inline]
+    pub const fn mask_cap(cap: usize) -> usize {
+        (cap & MASK_HI) >> 4
+    }
 }
 
 impl InternalCapacity for Lean {


### PR DESCRIPTION
I didn't want to use `as_ptr` because that exists on `Deref` with `str` Target. I don't like this name, but it's very explicit and long so it won't be confused with `std` which doesn't use `get_`.

Alternatively, maybe `as_raw_ptr` would be good. But IMO it's way to similar to `as_ptr`, so I opted for `get_raw_ptr` because it's clear what it does and just enough imperfect/annoying to make collisions with Cowed types unlikely.

Once const traits get into stable, this could maybe be deprecated and point to `str::as_ptr` or `addr_of!(**deref)`. But I feel like that won't be the case for additional 4-5 years.